### PR TITLE
openjpeg 2.4.0: rebuild for osx-arm64

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 mkdir build
 cd build
 
-cmake -G "%CMAKE_GENERATOR%" ^
+cmake -GNinja ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -D TIFF_LIBRARY=%LIBRARY_LIB%\tiff.lib ^
       -D TIFF_INCLUDE_DIR=%LIBRARY_INC% ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # good compatibility in 2.x series, check before new release
     # http://www.openjpeg.org/abi-check/timeline/openjpeg/
@@ -24,7 +24,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - make  # [unix]
+    - make   # [unix]
+    - ninja  # [win]
   host:
     - libtiff
     - libpng
@@ -37,10 +38,19 @@ test:
     - opj_dump -i p0_01.j2k
 
 about:
-    home: http://www.openjpeg.org/
-    license: BSD 2-Clause
+    home: https://www.openjpeg.org/
+    dev_url: https://github.com/uclouvain/openjpeg
+    doc_url: https://github.com/uclouvain/openjpeg/wiki/DocJ2KCodec
+    license: BSD-2-Clause
+    license_family: BSD
     license_file: LICENSE
-    summary: 'An open-source JPEG 2000 codec written in C'
+    summary: An open-source JPEG 2000 codec written in C.
+    description: |
+      OpenJPEG is an open-source JPEG 2000 codec written in C language.
+      It has been developed in order to promote the use of JPEG 2000,
+      a still-image compression standard from the Joint Photographic Experts Group (JPEG).
+      Since may 2015, it is officially recognized by ISO/IEC and ITU-T
+      as a JPEG 2000 Reference Software.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Rebuild because v2.4.0 is missing for the osx-arm64 platform. 