### PR TITLE
Update 2.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.0" %}
+{% set version = "2.5.2" %}
 
 package:
   name: openjpeg
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/uclouvain/openjpeg/archive/v{{ version }}.tar.gz
-  sha256: 8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d
+  sha256: 90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a
 
 build:
-  number: 2
+  number: 0
   run_exports:
     # good compatibility in 2.x series, check before new release
     # http://www.openjpeg.org/abi-check/timeline/openjpeg/


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/uclouvain/openjpeg)
- [Upstream changelog/diff](https://github.com/uclouvain/openjpeg/compare/v2.3.0...v2.5.2)
- [conda-forge](https://github.com/conda-forge/openjpeg-feedstock)

### Explanation of changes:

- current openjpeg for windows is [missing a .pc file](https://conda-metadata-app.streamlit.app/?q=pkgs%2Fmain%2Fwin-64%2Fopenjpeg-2.4.0-h4fc8c34_0.conda).
- not needed in the end (for ffmpeg), but did the work so thought maybe it's useful in future?
- Updated to 2.5.2 by pulling conda-forge changes
