### PR TITLE
release build for openjpeg 2.4.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,7 @@ cd build
 
 cmake -GNinja ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-      -D CMAKE_BUILD_TYPE=Release ^
+      %CMAKE_ARGS% ^
       -D BUILD_SHARED_LIBS=ON ^
       -D TIFF_LIBRARY=%LIBRARY_LIB%\tiff.lib ^
       -D TIFF_INCLUDE_DIR=%LIBRARY_INC% ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,8 @@ cd build
 
 cmake -GNinja ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D CMAKE_BUILD_TYPE=Release ^
+      -D BUILD_SHARED_LIBS=ON ^
       -D TIFF_LIBRARY=%LIBRARY_LIB%\tiff.lib ^
       -D TIFF_INCLUDE_DIR=%LIBRARY_INC% ^
       -D PNG_LIBRARY_RELEASE=%LIBRARY_LIB%\libpng.lib ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,6 +4,7 @@ cd build
 cmake -GNinja ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       %CMAKE_ARGS% ^
+      -D CMAKE_BUILD_TYPE=Release ^
       -D BUILD_SHARED_LIBS=ON ^
       -D TIFF_LIBRARY=%LIBRARY_LIB%\tiff.lib ^
       -D TIFF_INCLUDE_DIR=%LIBRARY_INC% ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,8 @@ mkdir build || true
 pushd build
 
   cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
         -DTIFF_LIBRARY=$PREFIX/lib/libtiff${SHLIB_EXT} \
         -DTIFF_INCLUDE_DIR=$PREFIX/include \
         -DPNG_LIBRARY_RELEASE=$PREFIX/lib/libpng${SHLIB_EXT} \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ mkdir build || true
 pushd build
 
   cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
-        -DCMAKE_BUILD_TYPE=Release \
+        $CMAKE_ARGS \
         -DBUILD_SHARED_LIBS=ON \
         -DTIFF_LIBRARY=$PREFIX/lib/libtiff${SHLIB_EXT} \
         -DTIFF_INCLUDE_DIR=$PREFIX/include \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,7 @@ pushd build
 
   cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
         $CMAKE_ARGS \
+        -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DTIFF_LIBRARY=$PREFIX/lib/libtiff${SHLIB_EXT} \
         -DTIFF_INCLUDE_DIR=$PREFIX/include \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # good compatibility in 2.x series, check before new release
     # http://www.openjpeg.org/abi-check/timeline/openjpeg/


### PR DESCRIPTION
openjpeg 2.4.0 b2

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-5265

### Explanation of changes:

- The last openjpeg build (2.4.0 b1) was linked against the debug version of the vs runtime. This caused issues loading pillow on system missing the debug version of the runtime.
